### PR TITLE
Added new options for deferred crawling standoff annotation

### DIFF
--- a/bifixer/bifixer.py
+++ b/bifixer/bifixer.py
@@ -56,8 +56,8 @@ def initialization():
     # Format
     groupO.add_argument("--scol", default=3, type=util.check_positive, help="Source sentence column (starting in 1)")
     groupO.add_argument("--tcol", default=4, type=util.check_positive, help="Target sentence column (starting in 1)")
-    groupO.add_argument("--sdeferredcol", default=6, type=util.check_positive, help="Source deferred standoff annotation column (starting in 1)")
-    groupO.add_argument("--tdeferredcol", default=7, type=util.check_positive, help="Target deferred standoff annotation column (starting in 1)")
+    groupO.add_argument("--sdeferredcol", type=util.check_positive, help="Source deferred standoff annotation column (starting in 1)")
+    groupO.add_argument("--tdeferredcol", type=util.check_positive, help="Target deferred standoff annotation column (starting in 1)")
        
 
     # Character fixing
@@ -191,12 +191,13 @@ def fix_sentences(args):
                 
                 if len(segments) > 1:
                     sent_num += 1
-                    if "#" in parts[args.sdeferredcol-1]:
-                        if sent_num != int(parts[args.sdeferredcol-1].split('#')[1]):
-                            continue
-                    else:
-                        new_parts[args.sdeferredcol-1] = parts[args.sdeferredcol-1].rstrip("\n")+"#"+str(sent_num)
-                        new_parts[args.tdeferredcol-1] = parts[args.tdeferredcol-1].rstrip("\n")+"#"+str(sent_num)
+                    if args.sdeferredcol and args.tdeferredcol:
+                        if "#" in parts[args.sdeferredcol-1]:
+                            if sent_num != int(parts[args.sdeferredcol-1].split('#')[1]):
+                                continue
+                        else:
+                            new_parts[args.sdeferredcol-1] = parts[args.sdeferredcol-1].rstrip("\n")+"#"+str(sent_num)
+                            new_parts[args.tdeferredcol-1] = parts[args.tdeferredcol-1].rstrip("\n")+"#"+str(sent_num)
 
                 if args.ignore_empty or (new_parts[args.scol - 1] and new_parts[args.tcol - 1]):  # sentence sides may be empty now because it contained only spaces or similar weird thing
                     if (args.dedup):


### PR DESCRIPTION
This is necessary for a correct reconstruction, as bifixer could split a long input sentence into several ones. This PR implements a modifier for the checksum annotation (usually at columns 6 and 7), indicating where these subsentences are located in the sentence splitter output (given the same sentence splitter in Bitextor/production process and the reconstruction). Then, at the reconstruction time, if this numeric indication is found, only the specified subsentence from the splitter is written in the output.

This pull request relates to https://github.com/bitextor/bitextor/pull/211