### PR TITLE
Bifixer installation with pip

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "segment"]
-	path = segment
-	url = https://github.com/mbanon/segment.git

--- a/README.md
+++ b/README.md
@@ -48,8 +48,12 @@ If you find Bifixer useful, please consider citing the following paper:
 
 ## INSTALLATION ##
 
- ```bash
- pip install "bifixer @ git+https://github.com/bitextor/bifixer.git"
+Install from source:
+
+```bash
+git clone https://github.com/bitextor/bifixer
+cd bifixer
+pip install .
 ```
 
 Automatic testing was added to ensure that everything is working fine in Bifixer:
@@ -57,6 +61,12 @@ Automatic testing was added to ensure that everything is working fine in Bifixer
 ```bash
 cd bifixer/tests
 pytest
+```
+
+Or install without manually downloading the repo:
+
+```bash
+pip install "bifixer @ git+https://github.com/bitextor/bifixer.git"
 ```
 
 ### Loomchild segmenter ###

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you find Bifixer useful, please consider citing the following paper:
 ## INSTALLATION ##
 
  ```bash
- pip install git+https://github.com/bitextor/bifixer.git
+ pip install "bifixer @ git+https://github.com/bitextor/bifixer.git"
 ```
 
 Automatic testing was added to ensure that everything is working fine in Bifixer:
@@ -64,7 +64,7 @@ pytest
 Please note that, in order to use the optional `loomchild` segmenter module in Java, it has to be specified as an optional dependency during installation:
 
 ```bash
-pip install git+https://github.com/bitextor/bifixer.git[loomchild]
+pip install "bifixer[loomchild] @ git+https://github.com/bitextor/bifixer.git"
 ```
 
 In case you are not using Java 8 as default, download it and overwrite the 'JAVA_HOME' variable before installing, for example:

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 ### Bifixer ###
 
 ```bash
-usage: bifixer.py [-h] [--scol SCOL] [--tcol TCOL] 
+usage: bifixer [-h] [--scol SCOL] [--tcol TCOL] 
                   [--ignore_characters]
                   [--ignore_empty] 
                   [--ignore_long]
@@ -177,18 +177,18 @@ Optional:
 ### Single thread run ###
 
 ```bash
-python3.6 bifixer/bifixer.py input-corpus.en-es output-corpus.en-es en es 
+bifixer input-corpus.en-es output-corpus.en-es en es 
 ```
 
 ### Running in parallel ###
 
-`bifixer.py` can be parallelized by using your favourite method (for example, GNU parallel)
+`bifixer` can be parallelized by using your favourite method (for example, GNU parallel)
 
 Suggested usage:
 
 ```bash
 cat input-corpus.en-es \
-    | parallel -j 25 --pipe -k -l 30000 python3.7 bifixer.py -q - - en es \
+    | parallel -j 25 --pipe -k -l 30000 bifixer -q - - en es \
     > output-corpus.en-es 
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Tool to fix bitexts and tag near-duplicates for removal.
 ![License](https://img.shields.io/badge/License-GPLv3-blue.svg)
 
 ## What can BIFIXER do to your parallel corpora ##
+
 * Fixes several text issues:
   * Fixes mojibake
-  * Turns HTML entities into the character they represent 
+  * Turns HTML entities into the character they represent
   * Replaces characters from wrong alphabets with the correct ones
   * Deactivate this feature with `--ignore_characters`  
 * Fixes common orthographic errors for some languages:
@@ -22,7 +23,7 @@ Tool to fix bitexts and tag near-duplicates for removal.
   * Choose the minimum length (in words) you want to start segmenting at (default is 15) with `--words_before_segmenting`. Set it to 1 to try to segment all sentences.
   * Deactivate this feature with `--ignore_segmentation`
 
-## Citation 
+## Citation
 
 If you find Bifixer useful, please consider citing the following paper:
 
@@ -44,35 +45,31 @@ If you find Bifixer useful, please consider citing the following paper:
   publisher = {European Association for Machine Translation}
 }
 ```
- 
+
 ## INSTALLATION ##
- 
+
  ```bash
- python3.7 -m pip install -r bifixer/requirements.txt
+ pip install git+https://github.com/bitextor/bifixer.git
 ```
+
 Automatic testing was added to ensure that everything is working fine in Bifixer:
 
 ```bash
 cd bifixer/tests
 pytest
 ```
+
 ### Loomchild segmenter ###
 
-Please note that, in order to use the optional `loomchild` segmenter module in Java, it has to be installed separatelly. Please follow [this](https://github.com/mbanon/segment#installation) extra instructions:
+Please note that, in order to use the optional `loomchild` segmenter module in Java, it has to be specified as an optional dependency during installation:
 
 ```bash
-git submodule foreach git pull
-cd segment/segment
-mvn clean install
-cd ../segment-ui
-mvn clean install
-cd target
-unzip segment-2.0.2-SNAPSHOT.zip
+pip install git+https://github.com/bitextor/bifixer.git[loomchild]
 ```
 
 In case you are not using Java 8 as default, download it and overwrite the 'JAVA_HOME' variable before installing, for example:
 
-```
+```bash
 export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 ```
 
@@ -80,11 +77,11 @@ export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 
 ### Bifixer ###
 
-```
+```bash
 usage: bifixer.py [-h] [--scol SCOL] [--tcol TCOL] 
                   [--ignore_characters]
                   [--ignore_empty] 
-		  [--ignore_long]
+                  [--ignore_long]
                   [--ignore_orthography]
                   [--ignore_duplicates] [--aggressive_dedup]
                   [--ignore_segmentation] [--words_before_segmenting WORDS_BEFORE_SEGMENTING] [--segmenter {nltk,loomchild}]
@@ -141,30 +138,30 @@ Logging:
 ### Parameters ###
 
 * Positional:
-    * INPUT : Input file. Tab-separated bilingual input file. By default, the expected columns are: SRC_URL TRG_URL SRC_SENTENCE TRG_SENTENCE [EXTRA COLUMNS]. When INPUT is -, reads standard input.
-    * OUTPUT : Output file. Tab-separated bilingual output file, being a fixed version of the input file. By default, the output columns are: SRC_URL TRG_URL SRC_SENTENCE TRG_SENTENCE [EXTRA COLUMNS] HASH RANKING. When OUTPUT is -, writes standard input.
-    * SRC LANG : Source language code (2-letter ISO 639-1 code)
-    * TRG LANG : Target language code (2-letter ISO 639-1 code)
-* Optional:
-    * --tmp_dir TMP_DIR : Directory for temporary files
-    * --scol SCOL : Position of the source sentence column (starting in 1). Default: 3
-    * --tcol TCOL : Position of the target sentence column (starting in 1). Default: 4
-    * --ignore_duplicates : Deactivates deduplication (won't add hash or ranking)
-    * --ignore_empty : Doesn't remove sentences with empty source or target
-    * --ignore_long: Doesn't remove too long sentences
-    * --ignore_segmentation : Deactivates segmentation of long sentences
-    * --segmenter: Segmenter module (`nltk` or `loomchild`)
-    * --words_before_segmenting : Maximum allowed amount of words in a sentence, before trying to segment it. Default: 15
-    * --ignore_characters : Deactivates text fixing (characters, encoding...)
-    * --ignore_orthography  Deactivates orthography fixing
-    * --aggressive_dedup : Treats near-duplicated sentences as duplicates (normalizes sentences before hashing)
-    * --tmp_dir TMP_DIR : Directory for temporary files
-    * -q, --quiet : Silent logging mode
-    * --debug: Shows debug messages while running
-    * --logfile LOGFILE : Stores log into a file
-    * -v, --version : Shows version number and exits
-    * -h, --help: Shows help and exits
-    
+  * INPUT : Input file. Tab-separated bilingual input file. By default, the expected columns are: SRC_URL TRG_URL SRC_SENTENCE TRG_SENTENCE [EXTRA COLUMNS]. When INPUT is -, reads standard input.
+  * OUTPUT : Output file. Tab-separated bilingual output file, being a fixed version of the input file. By default, the output columns are: SRC_URL TRG_URL SRC_SENTENCE TRG_SENTENCE [EXTRA COLUMNS] HASH RANKING. When OUTPUT is -, writes standard input.
+  * SRC LANG : Source language code (2-letter ISO 639-1 code)
+  * TRG LANG : Target language code (2-letter ISO 639-1 code)
+Optional:
+  * --tmp_dir TMP_DIR : Directory for temporary files
+  * --scol SCOL : Position of the source sentence column (starting in 1). Default: 3
+  * --tcol TCOL : Position of the target sentence column (starting in 1). Default: 4
+  * --ignore_duplicates : Deactivates deduplication (won't add hash or ranking)
+  * --ignore_empty : Doesn't remove sentences with empty source or target
+  * --ignore_long: Doesn't remove too long sentences
+  * --ignore_segmentation : Deactivates segmentation of long sentences
+  * --segmenter: Segmenter module (`nltk` or `loomchild`)
+  * --words_before_segmenting : Maximum allowed amount of words in a sentence, before trying to segment it. Default: 15
+  * --ignore_characters : Deactivates text fixing (characters, encoding...)
+  * --ignore_orthography  Deactivates orthography fixing
+  * --aggressive_dedup : Treats near-duplicated sentences as duplicates (normalizes sentences before hashing)
+  * --tmp_dir TMP_DIR : Directory for temporary files
+  * -q, --quiet : Silent logging mode
+  * --debug: Shows debug messages while running
+  * --logfile LOGFILE : Stores log into a file
+  * -v, --version : Shows version number and exits
+  * -h, --help: Shows help and exits
+
 ## RUN ##
 
 ### Single thread run ###
@@ -177,30 +174,31 @@ python3.6 bifixer/bifixer.py input-corpus.en-es output-corpus.en-es en es
 
 `bifixer.py` can be parallelized by using your favourite method (for example, GNU parallel)
 
-Suggested usage: 
+Suggested usage:
 
 ```bash
 cat input-corpus.en-es \
     | parallel -j 25 --pipe -k -l 30000 python3.7 bifixer.py -q - - en es \
     > output-corpus.en-es 
 ```
+
 where the two '`-`' mean read from stdin and write to stdout, and the `-q` tells bifixer to be quiet in order to avoid logging a lot of information messages.
 
 ## TAGGING DUPLICATED AND NEAR-DUPLICATED SENTENCES ##
 
 In order to ease the later removal of duplicated or near-duplicated parallel sentences, Bifixer appends each parallel sentence two new fields: `hash`and `ranking`.
 
-The hash is obtained by using the [XXHash](http://www.xxhash.com) algorithm, applied after fixing source and target sentences  (`fixed_source+"\t"+fixed_target`). Sentences that are identical at this step (see example below) will get the same hash. 
+The hash is obtained by using the [XXHash](http://www.xxhash.com) algorithm, applied after fixing source and target sentences  (`fixed_source+"\t"+fixed_target`). Sentences that are identical at this step (see example below) will get the same hash.
 
-When using the `--aggressive_dedup` feature, fixed parallel sentences are also normalized (ignoring casing, accents and diacritics) before their hash is computed. Doing so, sentences that are near-duplicates (i.e. they only differ in casing or accents) will also get the same hash. Normalization is only used internally: the output sentences will not be normalized after Bifixer is applied. 
+When using the `--aggressive_dedup` feature, fixed parallel sentences are also normalized (ignoring casing, accents and diacritics) before their hash is computed. Doing so, sentences that are near-duplicates (i.e. they only differ in casing or accents) will also get the same hash. Normalization is only used internally: the output sentences will not be normalized after Bifixer is applied.
 
-A `ranking` column is added at the end of each line. When not using the `--aggressive_dedup` feature, the number is set to 1 by default. When using the `--aggressive_dedup` feature, a float number is provided. This number (interpreted as the higher the better) will be used at later step to help the deduplication algorithm to choose the best sentence from those sharing the same hash. If the ranking number is exactly the same for a group of sentences sharing the same hash, only a random one should be kept. Otherwise, the one with the highest ranking number should be kept. 
+A `ranking` column is added at the end of each line. When not using the `--aggressive_dedup` feature, the number is set to 1 by default. When using the `--aggressive_dedup` feature, a float number is provided. This number (interpreted as the higher the better) will be used at later step to help the deduplication algorithm to choose the best sentence from those sharing the same hash. If the ranking number is exactly the same for a group of sentences sharing the same hash, only a random one should be kept. Otherwise, the one with the highest ranking number should be kept.
 
 ## EXAMPLE ##
 
 Input file:
 
-```
+```text
 http://www.ehyz.com/2.html.tmp	http://www.ehyz.com/2.html.tmp	1 year ago NuVid	Hace 1 aÃ±o NuVid
 http://pandafoundation.com/index.php?page=7	http://pandafoundation.com/index.php?page=26	©2007 Chengdu Research Base of Giant Panda Breeding ! All Rights Reserved	©2017 Fundación para la Investigación de Cría del Panda Gigante de Chengdu/ ¡Todos los derechos reservados!     
 http://www.boliviamall.com/4520.html	http://www.boliviamall.com/4520.html	Welcome Guest 1! Would you like to log in ?	Bienvenido Invitado 1! ¿Le gustaria entrar ?    
@@ -211,7 +209,7 @@ http://www.boliviamall.com/4305.html	http://www.boliviamall.com/4305.html	Welcom
 
 Output file (using the '--aggressive_dedup' feature, otherwise ranking number would be 1 in all cases):
 
-```
+```text
  
 http://www.ehyz.com/2.html.tmp	http://www.ehyz.com/2.html.tmp	1 year ago NuVid	Hace 1 año NuVid	9f1f7c6fc775a23a	88.25
 http://pandafoundation.com/index.php?page=7	http://pandafoundation.com/index.php?page=26	©2007 Chengdu Research Base of Giant Panda Breeding ! All Rights Reserved	©2017 Fundación para la Investigación de Cría del Panda Gigante de Chengdu/ ¡Todos los derechos reservados!	d0278d1279f06823	91.93
@@ -220,9 +218,6 @@ http://pandafoundation.com/index.php?page=157	http://pandafoundation.com/index.p
 http://www.ehyz.com/6.html.tmp	http://www.ehyz.com/6.html.tmp	1 year ago NuVid	Hace 1 año NuVid	9f1f7c6fc775a23a	88.25
 http://www.boliviamall.com/4305.html	http://www.boliviamall.com/4305.html	Welcome Guest 12! Would you like to log in?	¡Bienvenido invitado 12! ¿Le gustaría entrar?	422aeefd8f056b30	92.78
 ```
-
-
-
 
 ___
 

--- a/bifixer/__init__.py
+++ b/bifixer/__init__.py
@@ -1,0 +1,7 @@
+#!/user/bin/env python
+
+name="bifixer"
+
+from . import util
+from . import restorative_cleaning
+from . import segmenter

--- a/bifixer/segmenter.py
+++ b/bifixer/segmenter.py
@@ -7,74 +7,16 @@ __version__ = "Version 0.2 # 23/08/2019 # Included NLTK segmenter # Marta Bañó
 import signal
 import json
 import os
-import importlib.util
 import nltk
+import sys
+import logging
 
-from toolwrapper import ToolWrapper
 from nltk import load
 
-
-class LoomchildSegmenter(ToolWrapper):
-    """A module for interfacing with a Java sentence segmenter. """
-
-    def __init__(self, lang="en"):
-
-        spec = importlib.util.find_spec('bifixer')
-        if (spec is None or spec.submodule_search_locations is None):
-            target_path = os.path.dirname(os.path.abspath(__file__)) + "/../segment/segment-ui/target"
-            srx_path = os.path.dirname(os.path.abspath(__file__)) + "/../segment/srx"
-        else:
-            target_path = os.path.join(spec.submodule_search_locations[0], "data")
-            srx_path = os.path.join(target_path, "srx")
-
-        self.lang = lang
-        self.rules = self.getBestRules(lang)
-
-        class_path = f"{target_path}/segment-2.0.2-SNAPSHOT/lib/*"
-        rules_path = f"{srx_path}/{self.rules}"
-
-        if self.rules != "DEFAULT":
-            argv = ["java", "-cp", class_path, "net.loomchild.segment.ui.console.Segment", "-l", self.lang, "-s",  rules_path, "-c"]
-        else:
-            argv = ["java", "-cp", class_path, "net.loomchild.segment.ui.console.Segment", "-l", lang, "-c"]
-
-        super().__init__(argv)
-
-    def __str__(self):
-        return "LoomchildSegmenter()".format()
-
-    def __call__(self, sentence):
-        assert isinstance(sentence, str)
-        sentence = sentence.rstrip("\n")
-        assert "\n" not in sentence
-        if not sentence:
-            return []
-        self.writeline(sentence)
-
-        return self.readline()
-
-    def getBestRules(self, lang):
-        # Based on benchmarks: https://docs.google.com/spreadsheets/d/1mGJ9MSyMlsK0EUDRC2J50uxApiti3ggnlrzAWn8rkMg/edit?usp=sharing
-
-        omegaTLangs = ["bg", "cs", "sl", "sv"]
-        ptdrLangs = ["el", "et", "fi", "hr", "hu", "lt", "lv"]
-        nonAggressiveLangs = ["es", "it", "nb", "nn"]
-        languageToolLangs = ["da", "de", "en", "fr", "nl", "pl", "pt", "ro", "sk", "sr", "uk"]
-
-        if lang in omegaTLangs:
-            return "OmegaT.srx"
-        elif lang in ptdrLangs:
-            return "PTDR.srx"
-        elif lang in nonAggressiveLangs:
-            return "NonAggressive.srx"
-        elif lang in languageToolLangs:
-            return "language_tools.segment.srx"
-        else:
-            return "DEFAULT"
-
-    def get_segmentation(self, sentence):
-        sentence_segments = json.loads(self(sentence))
-        return sentence_segments
+try:
+    from loomchild.segmenter import LoomchildSegmenter
+except ImportError:
+    pass
 
 class myTimeout(Exception):
     pass
@@ -177,7 +119,11 @@ class NLTKSegmenter:
 class NaiveSegmenter:
     def __init__(self, lang, module="nltk"):
         if module == "loomchild":
-            self.segmenter = LoomchildSegmenter(lang)
+            if "loomchild.segmenter" in sys.modules:
+                self.segmenter = LoomchildSegmenter(lang)
+            else:
+                logging.warning("Loomchild segmenter unavailable, falling back to NLTK")
+                self.segmenter = NLTKSegmenter(lang)
         elif module == "nltk":
             self.segmenter = NLTKSegmenter(lang)
         else:

--- a/bifixer/segmenter.py
+++ b/bifixer/segmenter.py
@@ -7,6 +7,7 @@ __version__ = "Version 0.2 # 23/08/2019 # Included NLTK segmenter # Marta Bañó
 import signal
 import json
 import os
+import importlib.util
 import nltk
 
 from toolwrapper import ToolWrapper
@@ -17,15 +18,25 @@ class LoomchildSegmenter(ToolWrapper):
     """A module for interfacing with a Java sentence segmenter. """
 
     def __init__(self, lang="en"):
-        curpath = os.path.dirname(os.path.abspath(__file__)) + "/"
-        self.lang = lang
 
+        spec = importlib.util.find_spec('bifixer')
+        if (spec is None or spec.submodule_search_locations is None):
+            target_path = os.path.dirname(os.path.abspath(__file__)) + "/../segment/segment-ui/target"
+            srx_path = os.path.dirname(os.path.abspath(__file__)) + "/../segment/srx"
+        else:
+            target_path = os.path.join(spec.submodule_search_locations[0], "data")
+            srx_path = os.path.join(target_path, "srx")
+
+        self.lang = lang
         self.rules = self.getBestRules(lang)
 
+        class_path = f"{target_path}/segment-2.0.2-SNAPSHOT/lib/*"
+        rules_path = f"{srx_path}/{self.rules}"
+
         if self.rules != "DEFAULT":
-            argv = ["java", "-cp", curpath + "../segment/segment-ui/target/segment-ui-2.0.2-SNAPSHOT.jar:" + curpath + "../segment/segment-ui/target/segment-2.0.2-SNAPSHOT/lib/*", "net.loomchild.segment.ui.console.Segment", "-l", self.lang, "-s", curpath + "../segment/srx/" + self.rules, "-c"]
+            argv = ["java", "-cp", class_path, "net.loomchild.segment.ui.console.Segment", "-l", self.lang, "-s",  rules_path, "-c"]
         else:
-            argv = ["java", "-cp", curpath + "../segment/segment-ui/target/segment-ui-2.0.2-SNAPSHOT.jar:" + curpath + "../segment/segment-ui/target/segment-2.0.2-SNAPSHOT/lib/*", "net.loomchild.segment.ui.console.Segment", "-l", lang, "-c"]
+            argv = ["java", "-cp", class_path, "net.loomchild.segment.ui.console.Segment", "-l", lang, "-c"]
 
         super().__init__(argv)
 

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -1,0 +1,1 @@
+loomchild-segment @ git+https://github.com/zuny26/loomchild-segment-py.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ ftfy==6.0.1
 nltk==3.5
 pytest==6.2.2
 regex==2021.3.17
-toolwrapper==2.1.0
 Unidecode==1.2.0
 xxhash==2.0.0

--- a/scripts/bifixer
+++ b/scripts/bifixer
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+import sys
+import logging
+import bifixer.util as util
+import bifixer.bifixer as bifixer
+
+def main(argv):
+    try:
+        util.logging_setup()
+        args = bifixer.initialization()
+        bifixer.main(args)
+    except Exception as es:
+        tb = traceback.format_exc()
+        logging.error(tb)
+        sys.exit(1)
+
+if __name__=="__main__":
+    main(sys.argv[1:])

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+import setuptools
+import subprocess
+import os.path
+import shutil
+from sys import argv
+
+def compile_loomchild(current_path):
+    jars = ["activation-1.1.1.jar",  "commons-cli-1.2.jar",  "commons-logging-1.1.1.jar",
+        "gson-2.8.0.jar",  "jaxb-api-2.3.0.jar",  "jaxb-core-2.3.0.jar",
+        "jaxb-impl-2.3.0.jar",  "junit-4.1.jar",  "segment-2.0.2-SNAPSHOT.jar",
+        "segment-2.0.2-SNAPSHOT-tests.jar",  "segment-ui-2.0.2-SNAPSHOT.jar"]
+
+    all_compiled = True
+    for f in jars:
+        if not os.path.isfile(os.path.join(current_path, "bifixer/data/segment-2.0.2-SNAPSHOT/lib", f)):
+            all_compiled = False
+            break
+
+    if not all_compiled:
+        subprocess.check_call(["mvn", "clean", "install"], cwd=os.path.join(current_path, "segment/segment"))
+        subprocess.check_call(["mvn", "clean", "install"], cwd=os.path.join(current_path, "segment/segment-ui"))
+        subprocess.check_call(["unzip", "-o", os.path.join(current_path, "segment/segment-ui/target/segment-2.0.2-SNAPSHOT.zip"), 
+            "segment-2.0.2-SNAPSHOT/lib/*", "-d", os.path.join(current_path, "bifixer/data")])
+
+    shutil.copytree(os.path.join(current_path, "segment/srx"), os.path.join(current_path, "bifixer/data/srx"), dirs_exist_ok=True)
+
+if __name__=="__main__":
+    with open("README.md", "r") as fh:
+        long_description = fh.read()
+    with open("requirements.txt") as rf:
+        requirements = rf.read().splitlines()
+
+    package_data_list=["replacements/*"] 
+
+    if "--install-loomchild" in argv:
+        # argv.remove("--install-loomchild")
+        compile_loomchild(os.path.dirname(os.path.abspath(__file__)))
+        package_data_list.append("data/segment-2.0.2-SNAPSHOT/lib/*.jar")
+        package_data_list.append("data/srx/*.srx")
+
+    setuptools.setup(
+        name="bifixer",
+        #version="",
+        install_requires=requirements,
+        license="GNU General Public License v3.0",
+        author="Prompsit Language Engineering",
+        #author_email="",
+        #maintainer="",
+        #maintainer_email="",
+        #description="",
+        long_description=long_description,
+        long_description_content_type="text/markdown",
+        url="https://github.com/bitextor/bifixer",
+        packages=["bifixer"],
+        package_data={"bifixer": package_data_list},
+        classifiers=[
+            "Environment :: Console",
+            "Intended Audience :: Science/Research",
+            "Programming Language :: Python :: 3.7",
+            "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+            "Operating System :: POSIX :: Linux",
+            "Topic :: Scientific/Engineering :: Artificial Intelligence",
+            "Topic :: Text Processing :: Linguistic",
+            "Topic :: Software Development :: Libraries :: Python Modules",
+            "Topic :: Text Processing :: Filters"
+        ],
+        project_urls={
+            "Bifixer on GitHub": "https://github.com/bitextor/bifixer",
+            "Prompsit Language Engineering": "http://www.prompsit.com",
+            "Paracrawl": "https://paracrawl.eu/"
+             },
+        scripts=["scripts/bifixer"]     
+    )

--- a/setup.py
+++ b/setup.py
@@ -3,58 +3,31 @@
 import setuptools
 import subprocess
 import os.path
-import shutil
-from sys import argv
-
-def compile_loomchild(current_path):
-    jars = ["activation-1.1.1.jar",  "commons-cli-1.2.jar",  "commons-logging-1.1.1.jar",
-        "gson-2.8.0.jar",  "jaxb-api-2.3.0.jar",  "jaxb-core-2.3.0.jar",
-        "jaxb-impl-2.3.0.jar",  "junit-4.1.jar",  "segment-2.0.2-SNAPSHOT.jar",
-        "segment-2.0.2-SNAPSHOT-tests.jar",  "segment-ui-2.0.2-SNAPSHOT.jar"]
-
-    all_compiled = True
-    for f in jars:
-        if not os.path.isfile(os.path.join(current_path, "bifixer/data/segment-2.0.2-SNAPSHOT/lib", f)):
-            all_compiled = False
-            break
-
-    if not all_compiled:
-        subprocess.check_call(["mvn", "clean", "install"], cwd=os.path.join(current_path, "segment/segment"))
-        subprocess.check_call(["mvn", "clean", "install"], cwd=os.path.join(current_path, "segment/segment-ui"))
-        subprocess.check_call(["unzip", "-o", os.path.join(current_path, "segment/segment-ui/target/segment-2.0.2-SNAPSHOT.zip"), 
-            "segment-2.0.2-SNAPSHOT/lib/*", "-d", os.path.join(current_path, "bifixer/data")])
-
-    shutil.copytree(os.path.join(current_path, "segment/srx"), os.path.join(current_path, "bifixer/data/srx"), dirs_exist_ok=True)
 
 if __name__=="__main__":
     with open("README.md", "r") as fh:
         long_description = fh.read()
     with open("requirements.txt") as rf:
         requirements = rf.read().splitlines()
-
-    package_data_list=["replacements/*"] 
-
-    if "--install-loomchild" in argv:
-        argv.remove("--install-loomchild")
-        compile_loomchild(os.path.dirname(os.path.abspath(__file__)))
-        package_data_list.append("data/segment-2.0.2-SNAPSHOT/lib/*.jar")
-        package_data_list.append("data/srx/*.srx")
+    with open("optional-requirements.txt") as ef:
+        extras_requirements = ef.read().splitlines()
 
     setuptools.setup(
         name="bifixer",
-        #version="",
+        version="0.1",
         install_requires=requirements,
+        extras_require={"loomchild": extras_requirements},
         license="GNU General Public License v3.0",
         author="Prompsit Language Engineering",
-        #author_email="",
-        #maintainer="",
-        #maintainer_email="",
-        #description="",
+        author_email="info@prompsit.com",
+        description="Tool to fix bitexts and tag near-duplicates for removal",
+        maintainer="Marta Bañon",
+        maintainer_email="mbanon@prompsit.com",
         long_description=long_description,
         long_description_content_type="text/markdown",
         url="https://github.com/bitextor/bifixer",
         packages=["bifixer"],
-        package_data={"bifixer": package_data_list},
+        package_data={"bifixer": ["replacements/*"]},
         classifiers=[
             "Environment :: Console",
             "Intended Audience :: Science/Research",
@@ -71,5 +44,5 @@ if __name__=="__main__":
             "Prompsit Language Engineering": "http://www.prompsit.com",
             "Paracrawl": "https://paracrawl.eu/"
              },
-        scripts=["scripts/bifixer"]     
+        scripts=["scripts/bifixer"]
     )

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if __name__=="__main__":
     package_data_list=["replacements/*"] 
 
     if "--install-loomchild" in argv:
-        # argv.remove("--install-loomchild")
+        argv.remove("--install-loomchild")
         compile_loomchild(os.path.dirname(os.path.abspath(__file__)))
         package_data_list.append("data/segment-2.0.2-SNAPSHOT/lib/*.jar")
         package_data_list.append("data/srx/*.srx")

--- a/tests/test_bifixer.py
+++ b/tests/test_bifixer.py
@@ -144,16 +144,15 @@ class TestSegmenters:
 
     def test_Loomchild(self, capsys):
 
-        try:
-            segmenter_es = segmenter.NaiveSegmenter("es", "loomchild")
-            segmenter_en = segmenter.NaiveSegmenter("en", "loomchild")
-            segments = segmenter.naive_segmenter(segmenter_es, segmenter_en, self.text_src, self.text_trg)
-
-        except Exception as ex:
+        if "loomchild.segmenter" not in sys.modules:
             with capsys.disabled():
-                print(ex)
                 print("\n************** Warning: The optional Loomchild Segmenter is not installed. Skipping test.******************\n")
             return
+
+        segmenter_es = segmenter.NaiveSegmenter("es", "loomchild")
+        segmenter_en = segmenter.NaiveSegmenter("en", "loomchild")
+
+        segments = segmenter.naive_segmenter(segmenter_es, segmenter_en, self.text_src, self.text_trg)
 
         assert len(segments) == 7
 


### PR DESCRIPTION
* Added `setup.py`
* Added `scripts/bifixer` that calls the main function from `bifixer.py`
* Moved loomchild segmenter dependency to an [external repo](https://github.com/zuny26/loomchild-segment-py) for easier installation
  * segment submodule removed
  * toolwrapper requirement removed from this repo
  * added `optional-requirements.txt` to include segment as an optional dependency 
  * updated tests

To install bifixer from this fork:
`pip install "bifixer @ git+https://github.com/zuny26/bifixer@setup"`

With loomchild:
`pip install "bifixer[loomchild] @ git+https://github.com/zuny26/bifixer@setup"`

I set the version of bifixer to `0.1` since there is no release on github, but I'm unsure about that, so feel free to change the version to something else :P