### PR TITLE
Add headers to input and output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 ### Bifixer ###
 
 ```bash
-usage: bifixer.py [-h] [--scol SCOL] [--tcol TCOL]
+usage: bifixer.py [-h] [--header] [--output_header OUTPUT_HEADER]
+                  [--scol SCOL] [--tcol TCOL]
                   [--sdeferredcol SDEFERREDCOL] [--tdeferredcol TDEFERREDCOL]
                   [--ignore_characters] [--ignore_empty] [--ignore_long]
                   [--ignore_orthography] [--ignore_detokenization]
@@ -115,14 +116,23 @@ optional arguments:
   -h, --help            show this help message and exit
 
 Optional:
-  --scol SCOL           Source sentence column (starting in 1) (default: 3)
-  --tcol TCOL           Target sentence column (starting in 1) (default: 4)
+  --header              Input file will have header (default: False)
+  --output_header OUTPUT_HEADER
+                        Output file header (separated by ',') (default: None)
+  --scol SCOL           Source sentence column (starting in 1). The name of
+                        the field is expected instead of the position if
+                        --header is set (default: 3)
+  --tcol TCOL           Target sentence column (starting in 1). The name of
+                        the field is expected instead of the position if
+                        --header is set (default: 4)
   --sdeferredcol SDEFERREDCOL
                         Source deferred standoff annotation column (starting
-                        in 1) (default: None)
+                        in 1). The name of the field is expected instead of
+                        the position if --header is set (default: None)
   --tdeferredcol TDEFERREDCOL
                         Target deferred standoff annotation column (starting
-                        in 1) (default: None)
+                        in 1). The name of the field is expected instead of
+                        the position if --header is set (default: None)
   --ignore_characters   Doesn't fix mojibake, orthography, or other character
                         issues (default: False)
   --ignore_empty        Doesn't remove sentences with empty source or target
@@ -165,8 +175,10 @@ Logging:
   * TRG LANG : Target language code (2-letter ISO 639-1 code)
 * Optional:
   * --tmp_dir TMP_DIR : Directory for temporary files
-  * --scol SCOL : Position of the source sentence column (starting in 1). Default: 3
-  * --tcol TCOL : Position of the target sentence column (starting in 1). Default: 4
+  * --header : Treats the first sentence of the input file as the header row
+  * --output_header OUTPUT_HEADER : Writes the provided fields as the header of the output file and adds additionals fields if necessary (the provided fields will be separated by ',')
+  * --scol SCOL : Position of the source sentence column (starting in 1). If `--header` is set, the expected value will be the name of the field. Default: 3 if `--header` is not set else src_text
+  * --tcol TCOL : Position of the target sentence column (starting in 1). If `--header` is set, the expected value will be the name of the field. Default: 4 if `--header` is not set else trg_text
   * --sdeferredcol SDEFERREDCOL : Source deferred standoff annotation column (starting in 1). Default: None
   * --tdeferredcol TDEFERREDCOL : Target deferred standoff annotation column (starting in 1). Default: None
   * --ignore_duplicates : Deactivates deduplication (won't add hash or ranking)
@@ -191,7 +203,8 @@ Logging:
 
 ```bash
 python3.7 bifixer/monofixer.py --help
-usage: monofixer.py [-h] [--scol SCOL] [--sdeferredcol SDEFERREDCOL]
+usage: monofixer.py [-h] 
+                    [--scol SCOL] [--sdeferredcol SDEFERREDCOL]
                     [--ignore_characters] [--ignore_long]
                     [--ignore_orthography] [--ignore_detokenization]
                     [--ignore_duplicates] [--aggressive_dedup]
@@ -210,10 +223,16 @@ optional arguments:
   -h, --help            show this help message and exit
 
 Optional:
-  --scol SCOL           Sentence column (starting in 1) (default: 2)
+  --header              Input file will have header (default: False)
+  --output_header OUTPUT_HEADER
+                        Output file header (separated by ',') (default: None)
+  --scol SCOL           Sentence column (starting in 1). The name of the
+                        field is expected instead of the position if --header
+                        is set (default: 2)
   --sdeferredcol SDEFERREDCOL
                         Source deferred standoff annotation column (starting
-                        in 1) (default: None)
+                        in 1). The name of the field is expected instead of
+                        the position if --header is set (default: None)
   --ignore_characters   Doesn't fix mojibake, orthography, or other character
                         issues (default: False)
   --ignore_long         Doesn't ignore too long sentences (default: False)
@@ -253,7 +272,9 @@ Logging:
   * LANG : Sentence language code (2-letter ISO 639-1 code)
 * Optional:
   * --tmp_dir TMP_DIR : Directory for temporary files
-  * --scol SCOL : Position of the source sentence column (starting in 1). Default: 2
+  * --header : Treats the first sentence of the input file as the header row
+  * --output_header OUTPUT_HEADER : Writes the provided fields as the header of the output file and adds additionals fields if necessary (the provided fields will be separated by ',')
+  * --scol SCOL : Position of the source sentence column (starting in 1). If `--header` is set, the expected value will be the name of the field. Default: 2 if `--header` is not set else src_text
   * --sdeferredcol SDEFERREDCOL  Sentence deferred standoff annotation column (starting in 1). Default: None
   * --ignore_duplicates : Deactivates deduplication (won't add hash or ranking)
   * --ignore_long: Doesn't remove too long sentences

--- a/README.md
+++ b/README.md
@@ -94,8 +94,7 @@ export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 ### Bifixer ###
 
 ```bash
-usage: bifixer.py [-h] [--header] [--output_header OUTPUT_HEADER]
-                  [--scol SCOL] [--tcol TCOL]
+usage: bifixer.py [-h] [--header] [--scol SCOL] [--tcol TCOL]
                   [--sdeferredcol SDEFERREDCOL] [--tdeferredcol TDEFERREDCOL]
                   [--ignore_characters] [--ignore_empty] [--ignore_long]
                   [--ignore_orthography] [--ignore_detokenization]
@@ -117,8 +116,6 @@ optional arguments:
 
 Optional:
   --header              Input file will have header (default: False)
-  --output_header OUTPUT_HEADER
-                        Output file header (separated by ',') (default: None)
   --scol SCOL           Source sentence column (starting in 1). The name of
                         the field is expected instead of the position if
                         --header is set (default: 3)
@@ -175,8 +172,7 @@ Logging:
   * TRG LANG : Target language code (2-letter ISO 639-1 code)
 * Optional:
   * --tmp_dir TMP_DIR : Directory for temporary files
-  * --header : Treats the first sentence of the input file as the header row
-  * --output_header OUTPUT_HEADER : Writes the provided fields as the header of the output file and adds additionals fields if necessary (the provided fields will be separated by ',')
+  * --header : Treats the first sentence of the input file as the header row. If set, the output will contain a header as well
   * --scol SCOL : Position of the source sentence column (starting in 1). If `--header` is set, the expected value will be the name of the field. Default: 3 if `--header` is not set else src_text
   * --tcol TCOL : Position of the target sentence column (starting in 1). If `--header` is set, the expected value will be the name of the field. Default: 4 if `--header` is not set else trg_text
   * --sdeferredcol SDEFERREDCOL : Source deferred standoff annotation column (starting in 1). Default: None
@@ -224,8 +220,6 @@ optional arguments:
 
 Optional:
   --header              Input file will have header (default: False)
-  --output_header OUTPUT_HEADER
-                        Output file header (separated by ',') (default: None)
   --scol SCOL           Sentence column (starting in 1). The name of the
                         field is expected instead of the position if --header
                         is set (default: 2)
@@ -272,8 +266,7 @@ Logging:
   * LANG : Sentence language code (2-letter ISO 639-1 code)
 * Optional:
   * --tmp_dir TMP_DIR : Directory for temporary files
-  * --header : Treats the first sentence of the input file as the header row
-  * --output_header OUTPUT_HEADER : Writes the provided fields as the header of the output file and adds additionals fields if necessary (the provided fields will be separated by ',')
+  * --header : Treats the first sentence of the input file as the header row. If set, the output will contain a header as well
   * --scol SCOL : Position of the source sentence column (starting in 1). If `--header` is set, the expected value will be the name of the field. Default: 2 if `--header` is not set else src_text
   * --sdeferredcol SDEFERREDCOL  Sentence deferred standoff annotation column (starting in 1). Default: None
   * --ignore_duplicates : Deactivates deduplication (won't add hash or ranking)

--- a/bifixer/bifixer.py
+++ b/bifixer/bifixer.py
@@ -60,7 +60,6 @@ def initialization():
     groupO = parser.add_argument_group('Optional')
     # Format
     groupO.add_argument("--header", action='store_true', help="Input file will have header")
-    groupO.add_argument("--output_header", action='store_true' if header else None, help="Output file header (separated by ','). If --header is set, those values will be used if this flag is set")
     groupO.add_argument("--scol", type=util.check_positive if not header else str, default=3 if not header else "src_text", help="Source sentence column (starting in 1). The name of the field is expected instead of the position if --header is set")
     groupO.add_argument("--tcol", type=util.check_positive if not header else str, default=4 if not header else "trg_text", help="Target sentence column (starting in 1). The name of the field is expected instead of the position if --header is set")
     groupO.add_argument("--sdeferredcol", type=util.check_positive if not header else str, help="Source deferred standoff annotation column (starting in 1). The name of the field is expected instead of the position if --header is set")
@@ -174,17 +173,8 @@ def fix_sentences(args):
 
             args.tparagraphid = int(header.index(args.tparagraphid)) + 1
 
-    if args.output_header:
-        if args.header:
-            if not 'header' in locals():
-                raise Exception("Unexpected: 'header' should be defined")
-
-            output_header = header
-        else:
-            output_header = args.output_header.strip().split(",")
-
         # Write the output header once
-        args.output.write("\t".join(output_header))
+        args.output.write("\t".join(header))
 
         if args.dedup:
             args.output.write("\tbifixer_hash\tbifixer_score")

--- a/bifixer/bifixer.py
+++ b/bifixer/bifixer.py
@@ -59,7 +59,8 @@ def initialization():
     # Options group
     groupO = parser.add_argument_group('Optional')
     # Format
-    groupO.add_argument("--header", action='store_true', help="Input and output file will expect and have a header, respectively")
+    groupO.add_argument("--header", action='store_true', help="Input file will have header")
+    groupO.add_argument("--output_header", help="Output file header (separated by ',')")
     groupO.add_argument("--scol", type=util.check_positive if not header else str, default=3 if not header else "src_text", help="Source sentence column (starting in 1). The name of the field is expected instead of the position if --header is set")
     groupO.add_argument("--tcol", type=util.check_positive if not header else str, default=4 if not header else "trg_text", help="Target sentence column (starting in 1). The name of the field is expected instead of the position if --header is set")
     groupO.add_argument("--sdeferredcol", type=util.check_positive if not header else str, help="Source deferred standoff annotation column (starting in 1). The name of the field is expected instead of the position if --header is set")
@@ -159,6 +160,15 @@ def fix_sentences(args):
 
             args.tdeferredcol = int(header.index(args.tdeferredcol)) + 1
 
+    if args.output_header:
+        # Write the output header once
+        args.output.write("\t".join(args.output_header.strip().split(",")))
+
+        if args.dedup:
+            args.output.write("\tbifixer_hash\tbifixer_score")
+
+        args.output.write("\n")
+
     for i in args.input:
         ilines += 1
         parts = i.split("\t")
@@ -202,7 +212,7 @@ def fix_sentences(args):
             sent_num = 0
             for segment in segments:
                 if not args.ignore_empty and (len(segment["source_segment"]) == 0 or len(segment["target_segment"]) == 0):
-                    continue;
+                    continue
                 if args.dedup:
                     if args.aggressive_dedup:
                         normalized_src = unidecode(segment["source_segment"].lower().translate(remove_non_alpha))

--- a/bifixer/bifixer.py
+++ b/bifixer/bifixer.py
@@ -46,15 +46,14 @@ def initialization():
     parser = argparse.ArgumentParser(prog=os.path.basename(sys.argv[0]), formatter_class=argparse.ArgumentDefaultsHelpFormatter, description=__doc__)
 
     # Mandatory parameters
-    groupM = parser.add_argument_group('Mandatory')
     # Input file
-    groupM.add_argument('input', type=argparse.FileType('rt'), default=None, help="Tab-separated files to be bifixed")
+    parser.add_argument('input', type=argparse.FileType('rt'), default=None, help="Tab-separated files to be bifixed")
     # Output file (corpus)
-    groupM.add_argument('output', type=argparse.FileType('w'), default=sys.stdout, help="Fixed corpus")
+    parser.add_argument('output', type=argparse.FileType('w'), default=sys.stdout, help="Fixed corpus")
     # Source language
-    groupM.add_argument("srclang", type=str, help="Source language (SL) of the input")
+    parser.add_argument("srclang", type=str, help="Source language (SL) of the input")
     # Target language
-    groupM.add_argument("trglang", type=str, help="Target language (TL) of the input")
+    parser.add_argument("trglang", type=str, help="Target language (TL) of the input")
 
     # Options group
     groupO = parser.add_argument_group('Optional')

--- a/bifixer/bifixer.py
+++ b/bifixer/bifixer.py
@@ -59,7 +59,7 @@ def initialization():
     groupO = parser.add_argument_group('Optional')
     # Format
     groupO.add_argument("--header", action='store_true', help="Input file will have header")
-    groupO.add_argument("--output_header", help="Output file header (separated by ',')")
+    groupO.add_argument("--output_header", action='store_true' if header else None, help="Output file header (separated by ','). If --header is set, those values will be used if this flag is set")
     groupO.add_argument("--scol", type=util.check_positive if not header else str, default=3 if not header else "src_text", help="Source sentence column (starting in 1). The name of the field is expected instead of the position if --header is set")
     groupO.add_argument("--tcol", type=util.check_positive if not header else str, default=4 if not header else "trg_text", help="Target sentence column (starting in 1). The name of the field is expected instead of the position if --header is set")
     groupO.add_argument("--sdeferredcol", type=util.check_positive if not header else str, help="Source deferred standoff annotation column (starting in 1). The name of the field is expected instead of the position if --header is set")
@@ -160,8 +160,16 @@ def fix_sentences(args):
             args.tdeferredcol = int(header.index(args.tdeferredcol)) + 1
 
     if args.output_header:
+        if args.header:
+            if not 'header' in locals():
+                raise Exception("Unexpected: 'header' should be defined")
+
+            output_header = header
+        else:
+            output_header = args.output_header.strip().split(",")
+
         # Write the output header once
-        args.output.write("\t".join(args.output_header.strip().split(",")))
+        args.output.write("\t".join(output_header))
 
         if args.dedup:
             args.output.write("\tbifixer_hash\tbifixer_score")

--- a/bifixer/monofixer.py
+++ b/bifixer/monofixer.py
@@ -58,7 +58,8 @@ def initialization():
     # Options group
     groupO = parser.add_argument_group('Optional')
     #Format
-    groupO.add_argument("--header", action='store_true', help="Input and output file will expect and have a header, respectively")
+    groupO.add_argument("--header", action='store_true', help="Input file will have header")
+    groupO.add_argument("--output_header", help="Output file header (separated by ',')")
     groupO.add_argument("--scol", type=util.check_positive if not header else str, default=2 if not header else "src_text", help ="Sentence column (starting in 1). The name of the field is expected instead of the position if --header is set")
     groupO.add_argument("--sdeferredcol", type=util.check_positive if not header else str, help="Source deferred standoff annotation column (starting in 1). The name of the field is expected instead of the position if --header is set")
 
@@ -148,6 +149,15 @@ def fix_sentences(args):
 
             args.sdeferredcol = int(header.index(args.sdeferredcol)) + 1
 
+    if args.output_header:
+        # Write the output header once
+        args.output.write("\t".join(args.output_header.strip().split(",")))
+
+        if args.dedup:
+            args.output.write("\tbifixer_hash\tbifixer_score")
+
+        args.output.write("\n")
+
     for i in args.input:
         ilines += 1
         parts = i.split("\t")
@@ -186,7 +196,7 @@ def fix_sentences(args):
 
         for segment in segments:
             if len(segment) == 0:
-                continue;
+                continue
             if args.dedup:
                 if args.aggressive_dedup:
                     #normalized_sentence = unidecode.unidecode(segment.lower().replace(" ", "").translate(str.maketrans('', '', string.punctuation+string.digits)))

--- a/bifixer/monofixer.py
+++ b/bifixer/monofixer.py
@@ -58,7 +58,6 @@ def initialization():
     groupO = parser.add_argument_group('Optional')
     #Format
     groupO.add_argument("--header", action='store_true', help="Input file will have header")
-    groupO.add_argument("--output_header", action='store_true' if header else None, help="Output file header (separated by ','). If --header is set, those values will be used if this flag is set")
     groupO.add_argument("--scol", type=util.check_positive if not header else str, default=2 if not header else "src_text", help ="Sentence column (starting in 1). The name of the field is expected instead of the position if --header is set")
     groupO.add_argument("--sdeferredcol", type=util.check_positive if not header else str, help="Source deferred standoff annotation column (starting in 1). The name of the field is expected instead of the position if --header is set")
     groupO.add_argument("--sparagraphid", type=util.check_positive if not header else str, help="Source paragraph identification column (starting in 1). The name of the field is expected instead of the position if --header is set")
@@ -155,17 +154,8 @@ def fix_sentences(args):
 
             args.sparagraphid = int(header.index(args.sparagraphid)) + 1
 
-    if args.output_header:
-        if args.header:
-            if not 'header' in locals():
-                raise Exception("Unexpected: 'header' should be defined")
-
-            output_header = header
-        else:
-            output_header = args.output_header.strip().split(",")
-
         # Write the output header once
-        args.output.write("\t".join(output_header))
+        args.output.write("\t".join(header))
 
         if args.dedup:
             args.output.write("\tbifixer_hash\tbifixer_score")

--- a/bifixer/monofixer.py
+++ b/bifixer/monofixer.py
@@ -58,7 +58,7 @@ def initialization():
     groupO = parser.add_argument_group('Optional')
     #Format
     groupO.add_argument("--header", action='store_true', help="Input file will have header")
-    groupO.add_argument("--output_header", help="Output file header (separated by ',')")
+    groupO.add_argument("--output_header", action='store_true' if header else None, help="Output file header (separated by ','). If --header is set, those values will be used if this flag is set")
     groupO.add_argument("--scol", type=util.check_positive if not header else str, default=2 if not header else "src_text", help ="Sentence column (starting in 1). The name of the field is expected instead of the position if --header is set")
     groupO.add_argument("--sdeferredcol", type=util.check_positive if not header else str, help="Source deferred standoff annotation column (starting in 1). The name of the field is expected instead of the position if --header is set")
 
@@ -149,8 +149,16 @@ def fix_sentences(args):
             args.sdeferredcol = int(header.index(args.sdeferredcol)) + 1
 
     if args.output_header:
+        if args.header:
+            if not 'header' in locals():
+                raise Exception("Unexpected: 'header' should be defined")
+
+            output_header = header
+        else:
+            output_header = args.output_header.strip().split(",")
+
         # Write the output header once
-        args.output.write("\t".join(args.output_header.strip().split(",")))
+        args.output.write("\t".join(output_header))
 
         if args.dedup:
             args.output.write("\tbifixer_hash\tbifixer_score")

--- a/bifixer/monofixer.py
+++ b/bifixer/monofixer.py
@@ -41,27 +41,26 @@ def initialization():
     
     ilines = 0    
     olines = 0
+    header = "--header" in sys.argv
     
     logging.info("Processing arguments...")
     parser = argparse.ArgumentParser(prog=os.path.basename(sys.argv[0]), formatter_class=argparse.ArgumentDefaultsHelpFormatter, description=__doc__)
     
     # Mandatory parameters
-    #Input file
-    parser.add_argument('input', type=argparse.FileType('rt'), default=None, help="Tab-separated file to be fixed")  
-    #Output file (corpus)
-    parser.add_argument('output', type=argparse.FileType('w'), default=sys.stdout, help="Fixed corpus")        
-    #Language
-    parser.add_argument("lang", type=str, help="Language of the input")
-
-    #Mandatory parameters
     groupM = parser.add_argument_group('Mandatory')
+    #Input file
+    groupM.add_argument('input', type=argparse.FileType('rt'), default=None, help="Tab-separated file to be fixed")
+    #Output file (corpus)
+    groupM.add_argument('output', type=argparse.FileType('w'), default=sys.stdout, help="Fixed corpus")
+    #Language
+    groupM.add_argument("lang", type=str, help="Language of the input")
 
     # Options group
     groupO = parser.add_argument_group('Optional')
     #Format
-    groupO.add_argument("--scol", default=2, type=util.check_positive, help ="Sentence column (starting in 1)")
-
-    groupO.add_argument("--sdeferredcol", type=util.check_positive, help="Source deferred standoff annotation column (starting in 1)")
+    groupO.add_argument("--header", action='store_true', help="Input and output file will expect and have a header, respectively")
+    groupO.add_argument("--scol", type=util.check_positive if not header else str, default=2 if not header else "src_text", help ="Sentence column (starting in 1). The name of the field is expected instead of the position if --header is set")
+    groupO.add_argument("--sdeferredcol", type=util.check_positive if not header else str, help="Source deferred standoff annotation column (starting in 1). The name of the field is expected instead of the position if --header is set")
 
     #Character fixing
     groupO.add_argument('--ignore_characters', default=False, action='store_true', help="Doesn't fix mojibake, orthography, or other character issues")
@@ -133,6 +132,21 @@ def fix_sentences(args):
         
     if not args.ignore_segmentation:
         lang_segmenter = segmenter.NaiveSegmenter(args.lang, args.segmenter)
+
+    if args.header:
+        header = next(args.input).strip().split("\t")
+
+        # Transform fields to idxs
+        if args.scol not in header:
+            raise Exception(f"The provided --scol '{args.scol}' is not in the input header")
+
+        args.scol = int(header.index(args.scol)) + 1
+
+        if args.sdeferredcol:
+            if args.sdeferredcol not in header:
+                raise Exception(f"The provided --sdeferredcol '{args.sdeferredcol}' is not in the input header")
+
+            args.sdeferredcol = int(header.index(args.sdeferredcol)) + 1
 
     for i in args.input:
         ilines += 1

--- a/bifixer/monofixer.py
+++ b/bifixer/monofixer.py
@@ -47,13 +47,12 @@ def initialization():
     parser = argparse.ArgumentParser(prog=os.path.basename(sys.argv[0]), formatter_class=argparse.ArgumentDefaultsHelpFormatter, description=__doc__)
     
     # Mandatory parameters
-    groupM = parser.add_argument_group('Mandatory')
     #Input file
-    groupM.add_argument('input', type=argparse.FileType('rt'), default=None, help="Tab-separated file to be fixed")
+    parser.add_argument('input', type=argparse.FileType('rt'), default=None, help="Tab-separated file to be fixed")
     #Output file (corpus)
-    groupM.add_argument('output', type=argparse.FileType('w'), default=sys.stdout, help="Fixed corpus")
+    parser.add_argument('output', type=argparse.FileType('w'), default=sys.stdout, help="Fixed corpus")
     #Language
-    groupM.add_argument("lang", type=str, help="Language of the input")
+    parser.add_argument("lang", type=str, help="Language of the input")
 
     # Options group
     groupO = parser.add_argument_group('Optional')

--- a/tests/test_bifixer.py
+++ b/tests/test_bifixer.py
@@ -35,6 +35,7 @@ class TestEmptySpaces():
     args.tdeferredcol = None
     args.sparagraphid = None
     args.tparagraphid = None
+    args.header = None
     args.ignore_empty = False
     args.ignore_long = False
     args.input = open("input_test_1.txt", "rt")
@@ -196,6 +197,7 @@ class TestDedup:
     args.tdeferredcol = None
     args.sparagraphid = None
     args.tparagraphid = None
+    args.header = None
     args.aggressive_dedup = False
     args.input = open("input_test_2.txt", "rt")
     args.output = open("output_test_dedup.txt", "w+")
@@ -235,6 +237,7 @@ class TestAggressiveDedup:
     args.tdeferredcol = None
     args.sparagraphid = None
     args.tparagraphid = None
+    args.header = None
     args.aggressive_dedup = True
     args.input = open("input_test_2.txt", "rt")
     args.output = open("output_test_aggr_dedup.txt", "w+")


### PR DESCRIPTION
The provided input file to either Bifixer or Monofixer now might contain an optional header. Optional output header. Changes:

- Option `--header` if the input file contains header. In that case, the options `--scol`, `--tcol`, `--sdeferredcol` and `--tdeferredcol` will be expected to be the name of the field of the header instead of the position.
- Option `--output_header <header_field_1>[,<header_field_2>[...]]` can be set in order to specify the output header fields. If is not set, there will not be output header. If `--header` is set, there will not be necessary to add the name of the fields to `--output_header` since the provided headers in the input file will be used in the output.
- Documentation updated according to these changes.

These changes have been tested with basic configuration of the tools and, apparently, does not add any unexpected behaviour beyond the mentioned input and output headers.

Edit:
I have removed the option `--output_header` since I think it is not useful and because the output fields can be extracted from the input header if set. Now, if `--header` is set, the output header will be printed using the provided values in the header.