### PR TITLE
Add sentence enumeration to paragraph identification when sentences are split

### DIFF
--- a/bifixer/bifixer.py
+++ b/bifixer/bifixer.py
@@ -11,7 +11,7 @@ __version__ = "Version 0.5 # 22/06/2021 # Replacements improvements and fix toke
 import os
 import sys
 import argparse
-import time
+import copy
 import traceback
 import logging
 
@@ -213,7 +213,7 @@ def fix_sentences(args):
                         ranking = 1
                 # if  dedupping: Add extra columnsn with hash and ranking in output file
                 # Restored parts object, with the fixed segment, overwritten for each pair of extra segments,
-                new_parts = parts
+                new_parts = copy.deepcopy(parts)
 
                 new_parts[args.scol - 1] = segment["source_segment"]
                 new_parts[args.tcol - 1] = segment["target_segment"]
@@ -224,7 +224,6 @@ def fix_sentences(args):
                     if args.sdeferredcol and args.tdeferredcol:
                         if "#" in parts[args.sdeferredcol - 1]:
                             # Reconstruction
-
                             if sent_num != int(parts[args.sdeferredcol - 1].split('#')[1]):
                                 continue
                         else:

--- a/bifixer/bifixer.py
+++ b/bifixer/bifixer.py
@@ -222,10 +222,14 @@ def fix_sentences(args):
                     sent_num += 1
 
                     if args.sdeferredcol and args.tdeferredcol:
-                        if "#" in parts[args.sdeferredcol - 1]:
+                        if "#" in parts[args.sdeferredcol - 1] or "#" in parts[args.tdeferredcol - 1]:
                             # Reconstruction
-                            if sent_num != int(parts[args.sdeferredcol - 1].split('#')[1]):
-                                continue
+                            if "#" in parts[args.sdeferredcol - 1]:
+                                if sent_num != int(parts[args.sdeferredcol - 1].split('#')[1]):
+                                    continue
+                            elif "#" in parts[args.tdeferredcol - 1]:
+                                if sent_num != int(parts[args.tdeferredcol - 1].split('#')[1]):
+                                    continue
                         else:
                             new_parts[args.sdeferredcol - 1] = parts[args.sdeferredcol - 1].rstrip("\n") + "#" + str(sent_num)
                             new_parts[args.tdeferredcol - 1] = parts[args.tdeferredcol - 1].rstrip("\n") + "#" + str(sent_num)

--- a/bifixer/bifixer.py
+++ b/bifixer/bifixer.py
@@ -64,6 +64,8 @@ def initialization():
     groupO.add_argument("--tcol", default=4, type=util.check_positive, help="Target sentence column (starting in 1)")
     groupO.add_argument("--sdeferredcol", type=util.check_positive, help="Source deferred standoff annotation column (starting in 1)")
     groupO.add_argument("--tdeferredcol", type=util.check_positive, help="Target deferred standoff annotation column (starting in 1)")
+    groupO.add_argument("--sparagraphid", type=util.check_positive, help="Source paragraph identification column (starting in 1)")
+    groupO.add_argument("--tparagraphid", type=util.check_positive, help="Target paragraph identification column (starting in 1)")
        
 
     # Character fixing
@@ -146,6 +148,14 @@ def fix_sentences(args):
         try:
             source_sentence = parts[args.scol - 1]
             target_sentence = parts[args.tcol - 1]
+
+            # Check optional indexes
+            if args.sdeferredcol and args.tdeferredcol:
+                parts[args.sdeferredcol - 1]
+                parts[args.tdeferredcol - 1]
+            if args.sparagraphid and args.tparagraphid:
+                parts[args.sparagraphid - 1]
+                parts[args.tparagraphid - 1]
         except IndexError:
             logging.error(traceback.format_exc())
             logging.error("Wrong column index on line " + str(ilines))
@@ -207,16 +217,22 @@ def fix_sentences(args):
 
                 new_parts[args.scol - 1] = segment["source_segment"]
                 new_parts[args.tcol - 1] = segment["target_segment"]
-                
+
                 if len(segments) > 1:
                     sent_num += 1
+
                     if args.sdeferredcol and args.tdeferredcol:
-                        if "#" in parts[args.sdeferredcol-1]:
-                            if sent_num != int(parts[args.sdeferredcol-1].split('#')[1]):
+                        if "#" in parts[args.sdeferredcol - 1]:
+                            # Reconstruction
+
+                            if sent_num != int(parts[args.sdeferredcol - 1].split('#')[1]):
                                 continue
                         else:
-                            new_parts[args.sdeferredcol-1] = parts[args.sdeferredcol-1].rstrip("\n")+"#"+str(sent_num)
-                            new_parts[args.tdeferredcol-1] = parts[args.tdeferredcol-1].rstrip("\n")+"#"+str(sent_num)
+                            new_parts[args.sdeferredcol - 1] = parts[args.sdeferredcol - 1].rstrip("\n") + "#" + str(sent_num)
+                            new_parts[args.tdeferredcol - 1] = parts[args.tdeferredcol - 1].rstrip("\n") + "#" + str(sent_num)
+                    if args.sparagraphid and args.tparagraphid:
+                        new_parts[args.sparagraphid - 1] = parts[args.sparagraphid - 1].rstrip("\n") + "#" + str(sent_num)
+                        new_parts[args.tparagraphid - 1] = parts[args.tparagraphid - 1].rstrip("\n") + "#" + str(sent_num)
 
                 if args.ignore_empty or (new_parts[args.scol - 1] and new_parts[args.tcol - 1]):  # sentence sides may be empty now because it contained only spaces or similar weird thing
                     if (args.dedup):

--- a/bifixer/monofixer.py
+++ b/bifixer/monofixer.py
@@ -211,6 +211,9 @@ def fix_sentences(args):
                         new_parts[args.sdeferredcol-1] = parts[args.sdeferredcol-1].rstrip("\n")+"#"+str(sent_num)
 
                 if args.sparagraphid:
+                    if "#" in parts[args.sparagraphid-1]:
+                        new_parts[args.sparagraphid-1] = parts[args.sparagraphid-1].rstrip("\n").split("#")[0]+"#"+str(sent_num)
+                    else:
                         new_parts[args.sparagraphid-1] = parts[args.sparagraphid-1].rstrip("\n")+"#"+str(sent_num)
                                 
             if  (new_parts[args.scol-1]):  #sentence may be empty now because it contained only spaces or similar weird thing

--- a/bifixer/monofixer.py
+++ b/bifixer/monofixer.py
@@ -62,6 +62,7 @@ def initialization():
     groupO.add_argument("--scol", default=2, type=util.check_positive, help ="Sentence column (starting in 1)")
 
     groupO.add_argument("--sdeferredcol", type=util.check_positive, help="Source deferred standoff annotation column (starting in 1)")
+    groupO.add_argument("--sparagraphid", type=util.check_positive, help="Source paragraph identification column (starting in 1)")
 
     #Character fixing
     groupO.add_argument('--ignore_characters', default=False, action='store_true', help="Doesn't fix mojibake, orthography, or other character issues")
@@ -142,6 +143,12 @@ def fix_sentences(args):
         try:
             sentence = parts[args.scol-1]
 
+            # Check optional indexes
+            if args.sdeferredcol:
+                parts[args.sdeferredcol-1]
+            if args.sparagraphid:
+                parts[args.sparagraphid-1]
+
         except IndexError:
             logging.error(traceback.format_exc())
             logging.error("Wrong column index on line " + str(ilines))
@@ -202,8 +209,9 @@ def fix_sentences(args):
                             continue
                     else:
                         new_parts[args.sdeferredcol-1] = parts[args.sdeferredcol-1].rstrip("\n")+"#"+str(sent_num)
-                 
 
+                if args.sparagraphid:
+                        new_parts[args.sparagraphid-1] = parts[args.sparagraphid-1].rstrip("\n")+"#"+str(sent_num)
                                 
             if  (new_parts[args.scol-1]):  #sentence may be empty now because it contained only spaces or similar weird thing
                 if (args.dedup):

--- a/bifixer/monofixer.py
+++ b/bifixer/monofixer.py
@@ -10,7 +10,7 @@ __version__ = "Version 0.4 # 03/02/2020 # Monofixer # Marta Bañón"
 import os
 import sys
 import argparse
-import time
+import copy
 import traceback
 import logging 
 
@@ -198,23 +198,21 @@ def fix_sentences(args):
                     ranking = 1
             #if  dedupping: Add extra columnsn with hash and ranking in output file
             #Restored parts object, with the fixed segment, overwritten for each extra segment
-            new_parts = parts                
+            new_parts = copy.deepcopy(parts)
             new_parts[args.scol-1] = segment
             
             if len(segments) > 1:
                 sent_num += 1
                 if args.sdeferredcol:
                     if "#" in parts[args.sdeferredcol-1]:
+                        # Reconstruction
                         if sent_num != int(parts[args.sdeferredcol-1].split('#')[1]):
                             continue
                     else:
                         new_parts[args.sdeferredcol-1] = parts[args.sdeferredcol-1].rstrip("\n")+"#"+str(sent_num)
 
                 if args.sparagraphid:
-                    if "#" in parts[args.sparagraphid-1]:
-                        new_parts[args.sparagraphid-1] = parts[args.sparagraphid-1].rstrip("\n").split("#")[0]+"#"+str(sent_num)
-                    else:
-                        new_parts[args.sparagraphid-1] = parts[args.sparagraphid-1].rstrip("\n")+"#"+str(sent_num)
+                    new_parts[args.sparagraphid-1] = parts[args.sparagraphid-1].rstrip("\n")+"#"+str(sent_num)
                                 
             if  (new_parts[args.scol-1]):  #sentence may be empty now because it contained only spaces or similar weird thing
                 if (args.dedup):


### PR DESCRIPTION
If paragraph identification data is provided in the input file and sentences are split, we would like to keep the sentence enumeration in order to reconstruct the split sentences.

The new behaviour is very similar to deferred (flags `--sdeferredcol` and `--tdeferredcol`). So, flags `--sparagraphid` and `--tparagraphid` are introduced in order to specify the columns of the source and target paragraph identification data.

If sentences are split, the value `#{no. sentence}` will be added to source and target paragraph identifiers, like it is done with deferred.